### PR TITLE
Live tournament

### DIFF
--- a/src/arena/ArenaForm.tsx
+++ b/src/arena/ArenaForm.tsx
@@ -7,7 +7,7 @@ import WebSocketContext from '../common/contexts/WebSocketContext';
 
 export default function ArenaForm() {
   const arenaContext = useContext(ArenaContext);
-  const send = useContext(WebSocketContext);
+  const { send } = useContext(WebSocketContext);
 
   const handleSubmit = (event: any) => {
     event.preventDefault();

--- a/src/arena/ArenaStarter.tsx
+++ b/src/arena/ArenaStarter.tsx
@@ -6,7 +6,7 @@ import WebSocketContext from '../common/contexts/WebSocketContext';
 import DefaultButton from '../common/ui/DefaultButton';
 
 export default function ArenaStarter() {
-  const send = useContext(WebSocketContext);
+  const { send } = useContext(WebSocketContext);
   const arena = useContext(ArenaContext);
 
   const startArena = (event: any) => {

--- a/src/common/contexts/WebSocketContext.tsx
+++ b/src/common/contexts/WebSocketContext.tsx
@@ -1,7 +1,15 @@
 import React from 'react';
 
-const WebSocketContext = React.createContext((message: any) => {
-  console.log('WEBSOCKETCONTEXT NOT SET YET');
+const WebSocketContext = React.createContext({
+  send: (message: any) => {
+    console.log('WEBSOCKETCONTEXT NOT SET YET');
+  },
+  subscribe: (subscriber: (msg: any) => void) => {
+    console.log('WEBSOCKETCONTEXT NOT SET YET');
+  },
+  unsubscribe: (subscriber: (msg: any) => void) => {
+    console.log('WEBSOCKETCONTEXT NOT SET YET');
+  },
 });
 
 export default WebSocketContext;

--- a/src/common/ui/TemplatePage.tsx
+++ b/src/common/ui/TemplatePage.tsx
@@ -46,7 +46,7 @@ export default function TemplatePage({ center, children }: TemplatePageProps) {
   const setters = useContext(SettersContext);
   const getActiveTournament = useRestAPIToGetActiveTournament(setters, tour);
   const [shouldFetch, setShouldFetch] = useState(true);
-  const send = useContext(WebSocketContext);
+  const { send } = useContext(WebSocketContext);
 
   useEffect(
     () => {

--- a/src/game/GameDirector.tsx
+++ b/src/game/GameDirector.tsx
@@ -19,6 +19,7 @@ import WebSocketContext from '../common/contexts/WebSocketContext';
 
 interface Props {
   id?: string;
+  tournamentIds?: string[];
 }
 
 interface State {
@@ -78,10 +79,12 @@ export default class GameDirector extends React.Component<Props, State> {
   }
 
   private onUpdateFromServer(data: any) {
-    this.events.push(data);
-    if (data.type === EventType.GAME_STARTING_EVENT) {
-      this.currentEventIndex = this.events.length - 1;
-      this.updateGameSpeedInterval(Config.DefaultGameSpeed);
+    if (this.props?.tournamentIds?.includes(data?.gameId)) {
+      this.events.push(data);
+      if (data.type === EventType.GAME_STARTING_EVENT) {
+        this.currentEventIndex = this.events.length - 1;
+        this.updateGameSpeedInterval(Config.DefaultGameSpeed);
+      }
     }
   }
 

--- a/src/game/GameDirector.tsx
+++ b/src/game/GameDirector.tsx
@@ -82,7 +82,9 @@ export default class GameDirector extends React.Component<Props, State> {
     if (this.props?.tournamentIds?.includes(data?.gameId)) {
       this.events.push(data);
       if (data.type === EventType.GAME_STARTING_EVENT) {
-        this.currentEventIndex = this.events.length - 1;
+        this.currentEventIndex = 0;
+        this.events.length = 0;
+        this.events.push(data);
         this.updateGameSpeedInterval(Config.DefaultGameSpeed);
       }
     }

--- a/src/game/GameDirector.tsx
+++ b/src/game/GameDirector.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ContextType } from 'react';
 import { Heading1 } from '../common/ui/Heading';
 import { Paper, PaperRow } from '../common/ui/Paper';
 import { CharacterColors } from '../common/Constants';
@@ -15,6 +15,7 @@ import {
   GameState,
   TileMap,
 } from './type';
+import WebSocketContext from '../common/contexts/WebSocketContext';
 
 interface Props {
   id?: string;
@@ -55,7 +56,9 @@ const colours = [
 // TODO Handle receiving results when EventType === GAME_RESULT_EVENT
 
 export default class GameDirector extends React.Component<Props, State> {
-  private ws?: WebSocket;
+  static contextType = WebSocketContext;
+
+  context!: ContextType<typeof WebSocketContext>;
   private readonly events: any[] = [];
   private currentEventIndex = 0;
   private timeInMsPerTick: number = Config.DefaultGameSpeed;
@@ -69,8 +72,17 @@ export default class GameDirector extends React.Component<Props, State> {
     error: undefined,
   };
 
-  private onUpdateFromServer(evt: MessageEvent) {
-    this.events.push(JSON.parse(evt.data));
+  constructor(props: Props) {
+    super(props);
+    this.onUpdateFromServer = this.onUpdateFromServer.bind(this);
+  }
+
+  private onUpdateFromServer(data: any) {
+    this.events.push(data);
+    if (data.type === EventType.GAME_STARTING_EVENT) {
+      this.currentEventIndex = this.events.length - 1;
+      this.updateGameSpeedInterval(Config.DefaultGameSpeed);
+    }
   }
 
   private readonly updateGameSpeedInterval = (milliseconds: number) => {
@@ -84,27 +96,29 @@ export default class GameDirector extends React.Component<Props, State> {
   };
 
   private playOneTick(eventIndex: number): void {
-    const data = this.events[eventIndex];
-    if (data) {
-      if (data.type === EventType.GAME_STARTING_EVENT) {
-        this.setState({
-          gameSettings: data.gameSettings as GameSettings,
-          gameState: data as GameState,
-        });
-      } else if (data.type === EventType.GAME_UPDATE_EVENT) {
-        this.setState({ gameState: data as GameState });
-        const prevData = eventIndex > 0 ? this.events[eventIndex - 1] : undefined;
-        const prevState = prevData && prevData.type === EventType.GAME_UPDATE_EVENT ? prevData : data;
-        this.setState({ gameBoardState: this.createGameBoardState(prevState.map, data.map) });
-      } else if (data.type === EventType.GAME_ENDED_EVENT) {
-        this.setState({ gameState: data as GameState });
-        const prevData = this.events[eventIndex - 2];
-        const prevState = (prevData && prevData.type === EventType.GAME_UPDATE_EVENT) ? prevData : data;
-        this.setState({ gameBoardState: this.createGameBoardState(prevState.map, data.map) });
+    if (eventIndex < this.events.length) {
+      const data = this.events[eventIndex];
+      if (data) {
+        if (data.type === EventType.GAME_STARTING_EVENT) {
+          this.setState({
+            gameSettings: data.gameSettings as GameSettings,
+            gameState: data as GameState,
+          });
+        } else if (data.type === EventType.GAME_UPDATE_EVENT) {
+          this.setState({ gameState: data as GameState });
+          const prevData = eventIndex > 0 ? this.events[eventIndex - 1] : undefined;
+          const prevState = prevData && prevData.type === EventType.GAME_UPDATE_EVENT ? prevData : data;
+          this.setState({ gameBoardState: this.createGameBoardState(prevState.map, data.map) });
+        } else if (data.type === EventType.GAME_ENDED_EVENT) {
+          this.setState({ gameState: data as GameState });
+          const prevData = this.events[eventIndex - 2];
+          const prevState = (prevData && prevData.type === EventType.GAME_UPDATE_EVENT) ? prevData : data;
+          this.setState({ gameBoardState: this.createGameBoardState(prevState.map, data.map) });
+        }
       }
-    }
 
-    this.currentEventIndex++;
+      this.currentEventIndex++;
+    }
   }
 
   private createGameBoardState(prevGameMap: GameMap, gameMap: GameMap): GameBoardState {
@@ -182,8 +196,8 @@ export default class GameDirector extends React.Component<Props, State> {
   }
 
   private endGame() {
-    if (this.ws !== undefined) {
-      this.ws.close();
+    if (!this.props.id) {
+      this.context.unsubscribe(this.onUpdateFromServer);
     }
     if (this.updateInterval !== undefined) {
       clearInterval(this.updateInterval);
@@ -225,9 +239,7 @@ export default class GameDirector extends React.Component<Props, State> {
     if (this.props.id) {
       this.fetchGame();
     } else {
-      this.ws = new WebSocket(Config.WebSocketApiUrl);
-      this.ws.onmessage = (evt: MessageEvent) => this.onUpdateFromServer(evt);
-      this.updateGameSpeedInterval(Config.DefaultGameSpeed);
+      this.context.subscribe(this.onUpdateFromServer);
     }
   }
 
@@ -257,7 +269,12 @@ export default class GameDirector extends React.Component<Props, State> {
     }
 
     if (!gameStatus) {
-      return <p>Loading game...</p>;
+      if (this.props.id) {
+        return <p>Loading game...</p>;
+      }
+      else {
+        return null;
+      }
     } else if (gameStatus === EventType.GAME_STARTING_EVENT) {
       return <p>Game is starting...</p>;
     } else if (
@@ -269,7 +286,7 @@ export default class GameDirector extends React.Component<Props, State> {
       && gameBoardState
       && gameSettings
     ) {
-      if (gameStatus === EventType.GAME_ENDED_EVENT) {
+      if (this.props.id && gameStatus === EventType.GAME_ENDED_EVENT) {
         this.endGame();
       }
       return (

--- a/src/tournament/TournamentCreator.tsx
+++ b/src/tournament/TournamentCreator.tsx
@@ -19,7 +19,7 @@ const Form = styled.form`
 export default function TournamentCreator() {
   const accContext = useContext(AccountContext);
   const [tourName, setTourName] = useState('');
-  const send = useContext(WebSocketContext);
+  const { send } = useContext(WebSocketContext);
 
   function handleSubmit(event: React.FormEvent) {
     event.preventDefault();

--- a/src/tournament/contr/Controls.tsx
+++ b/src/tournament/contr/Controls.tsx
@@ -42,7 +42,7 @@ export default function Controls({ started }: ControlsProps) {
   const showStart = !started && tour.gamePlan.players.length > 0;
   const accContext = useContext(AccountContext);
   const tourContext = useContext(TournamentContext);
-  const send = useContext(WebSocketContext);
+  const { send } = useContext(WebSocketContext);
 
   function handleStart() {
     const mess = {

--- a/src/tournament/contr/GamePlan.tsx
+++ b/src/tournament/contr/GamePlan.tsx
@@ -28,7 +28,7 @@ export default function GamePlan({ lvl, game, players, playedGames }: GamePlanPr
   const tour = useContext(TournamentContext);
   const levels = tour.gamePlan.tournamentLevels;
   const started = levels.length > 0 && levels[0].tournamentGames[0].gameId !== null;
-  const send = useContext(WebSocketContext);
+  const { send } = useContext(WebSocketContext);
   const acc = useContext(AccountContext);
   const noLevels = tour.gamePlan.noofLevels;
   const [showNextGame, setShowNextGame] = useState(lvl === 0 && game === 0 && !tour.winner);

--- a/src/tournament/contr/TournamentController.tsx
+++ b/src/tournament/contr/TournamentController.tsx
@@ -71,7 +71,9 @@ export default function TournamentController() {
 
   return (
     <div>
-      <GameDirector />
+      <GameDirector
+        tournamentIds={levels.flatMap(l => l.tournamentGames.map(g => g.gameId))}
+      />
       <PaperGrid>
         <div>
           <Paper>

--- a/src/tournament/contr/TournamentController.tsx
+++ b/src/tournament/contr/TournamentController.tsx
@@ -12,6 +12,7 @@ import GamePlan, { PlayedGame } from './GamePlan';
 import Players from './Players';
 import TournamentPropertySetter from './TournamentPropertySetter';
 import Settings from './Settings';
+import GameDirector from '../../game/GameDirector';
 
 interface NextGame {
   lvl: number;
@@ -20,9 +21,12 @@ interface NextGame {
 }
 
 const PaperGrid = styled.div`
-  width: 100%;
+  width: 60rem;
+  max-width: calc(100vw - 2rem);
   display: grid;
   gap: 1rem;
+  margin: auto;
+  margin-top: 1rem;
 
   @media screen and (min-width: 600px) {
     grid-template-columns: 1fr auto;
@@ -66,24 +70,27 @@ export default function TournamentController() {
   );
 
   return (
-    <PaperGrid>
-      <div>
-        <Paper>
-          <PaperRow>
-            <Heading1>{tour.tournamentName}</Heading1>
-            <p>It's on! Start the tournament once all players have joined.</p>
-            {acc.loggedIn && <Controls started={started} />}
-          </PaperRow>
-          <Players />
-        </Paper>
-        {started && (
-          <GamePlan lvl={nextGame.lvl} game={nextGame.game} players={nextGame.players} playedGames={playedGames} />
-        )}
-      </div>
-      <div>
-        {showSetters && <TournamentPropertySetter />}
-        {!showSetters && <Settings />}
-      </div>
-    </PaperGrid>
+    <div>
+      <GameDirector />
+      <PaperGrid>
+        <div>
+          <Paper>
+            <PaperRow>
+              <Heading1>{tour.tournamentName}</Heading1>
+              <p>It's on! Start the tournament once all players have joined.</p>
+              {acc.loggedIn && <Controls started={started} />}
+            </PaperRow>
+            <Players />
+          </Paper>
+          {started && (
+            <GamePlan lvl={nextGame.lvl} game={nextGame.game} players={nextGame.players} playedGames={playedGames} />
+          )}
+        </div>
+        <div>
+          {showSetters && <TournamentPropertySetter />}
+          {!showSetters && <Settings />}
+        </div>
+      </PaperGrid>
+    </div>
   );
 }

--- a/src/tournament/contr/TournamentGameLink.tsx
+++ b/src/tournament/contr/TournamentGameLink.tsx
@@ -11,7 +11,7 @@ import GameLink from '../../common/ui/GameLink';
 export default function TournamentGameLink(props: any) {
   const [clicked, setClicked] = useState(false);
   const accContext = useContext(AccountContext);
-  const send = useContext(WebSocketContext);
+  const { send } = useContext(WebSocketContext);
   const game: Game = props.game;
 
   const hc = (event: any) => {

--- a/src/tournament/contr/TournamentPropertySetter.tsx
+++ b/src/tournament/contr/TournamentPropertySetter.tsx
@@ -23,7 +23,7 @@ export default function TournamentPropertySetter() {
   const accContext = useContext(AccountContext);
   const [currentProperties, setCurrentProperties] = useState(tourContext);
   const gameSettings = currentProperties.gameSettings;
-  const send = useContext(WebSocketContext);
+  const { send } = useContext(WebSocketContext);
 
   const handleSubmit = (event: any) => {
     if (event !== null) {


### PR DESCRIPTION
This PR adds the capability to watch tournament games live. And should close #36 that requested this feature.

Visually this is done by adding a game view at the top of the tournament page that appears once a game is started. This game view can be used like the regular one, with all play/pause and speed controls.  
![A screenshot of the tournament page with the game view visible](https://user-images.githubusercontent.com/15267120/138549930-39690903-ce4f-4f95-90b6-93a236c768ea.jpeg)

To achieve this, I've added the ability to subscribe to web socket events via the WebSocket context.